### PR TITLE
[dart_lsc] Prepare for 1.0.0 version of sensors and package_info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.2.2
+
+* Prepare for 1.0.0 version of sensors and package_info. ([dart_lsc](http://github.com/amirh/dart_lsc))
+
 ## 3.2.1+2
 
 * Updated deps.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: google_map_location_picker
 description: '🌍 Map location picker for flutter Based on google_maps_flutter'
-version: 3.2.1+2
+version: 3.2.2
 homepage: https://github.com/humazed/google_map_location_picker
 
 #  flutter pub pub publish --dry-run
@@ -22,7 +22,7 @@ dependencies:
   provider: ^4.0.4
   http: ^0.12.0+4
   stack_trace: ^1.9.3
-  package_info: ^0.4.0+14
+  package_info: '>=0.4.0+14 <2.0.0'
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
This should be a safe change, for more details see: https://github.com/flutter/flutter/wiki/Package-migration-to-1.0.0

This change was auto generated by [dart_lsc](https://github.com/amirh/dart_lsc).