### PR TITLE
Add placeId to Location Result

### DIFF
--- a/lib/src/google_map_location_picker.dart
+++ b/lib/src/google_map_location_picker.dart
@@ -311,6 +311,8 @@ class LocationPickerState extends State<LocationPicker> {
 
       String road;
 
+      String placeId = responseJson['results'][0]['place_id'];
+
       if (responseJson['status'] == 'REQUEST_DENIED') {
         road = 'REQUEST DENIED = please see log for more details';
         print(responseJson['error_message']);
@@ -326,6 +328,7 @@ class LocationPickerState extends State<LocationPicker> {
         locationResult = LocationResult();
         locationResult.address = road;
         locationResult.latLng = latLng;
+        locationResult.placeId = placeId;
       });
     }
   }

--- a/lib/src/map.dart
+++ b/lib/src/map.dart
@@ -270,7 +270,7 @@ class MapPickerState extends State<MapPicker> {
       print(e);
     }
 
-    return null;
+    return {"placeId": null, "address": null};
   }
 
   Widget pin() {

--- a/lib/src/model/location_result.dart
+++ b/lib/src/model/location_result.dart
@@ -7,13 +7,16 @@ class LocationResult {
   /// places list, we use the <b>name</b> provided on the list item.
   String address; // or road
 
+  /// Google Maps place ID
+  String placeId;
+
   /// Latitude/Longitude of the selected location.
   LatLng latLng;
 
-  LocationResult({this.latLng, this.address});
+  LocationResult({this.latLng, this.address, this.placeId});
 
   @override
   String toString() {
-    return 'LocationResult{address: $address, latLng: $latLng}';
+    return 'LocationResult{address: $address, latLng: $latLng, placeId: $placeId}';
   }
 }


### PR DESCRIPTION
Place ID is useful for performing further API operations with location data. To avoid an additional API request, we may as well be returning it along with the LocationResult since we have it anyway. This pull request adds the placeId field to LocationResult and populates it in `map.dart` as well as `google_map_location_picker.dart`.