### PR TITLE
added GeolocationPermission.locationWhenInUse to GeoLocator

### DIFF
--- a/lib/src/map.dart
+++ b/lib/src/map.dart
@@ -92,7 +92,7 @@ class MapPickerState extends State<MapPicker> {
     Position currentPosition;
     try {
       currentPosition = await Geolocator()
-          .getCurrentPosition(desiredAccuracy: LocationAccuracy.best);
+          .getCurrentPosition(desiredAccuracy: LocationAccuracy.best, locationPermissionLevel: GeolocationPermission.locationWhenInUse);
 
       d("position = $currentPosition");
 


### PR DESCRIPTION
GeLocator by default requests while in use and all time background location permissions, while the map does not seem to require background location, this change will ensure the plugin does not request and trigger the background location permission request.