### PR TITLE
Add margin for float button aka MapFabs

### DIFF
--- a/lib/src/google_map_location_picker.dart
+++ b/lib/src/google_map_location_picker.dart
@@ -69,7 +69,6 @@ class LocationPicker extends StatefulWidget {
   final LocationAccuracy desiredAccuracy;
   final EdgeInsets buttonMargin;
 
-
   @override
   LocationPickerState createState() => LocationPickerState();
 }
@@ -466,7 +465,8 @@ Future<LocationResult> showLocationPicker(
   Decoration resultCardDecoration,
   String language = 'en',
   LocationAccuracy desiredAccuracy = LocationAccuracy.best,
-  EdgeInsets buttonMargin = EdgeInsets.only(top: kToolbarHeight + 50, right: 8),
+  EdgeInsets buttonMargin =
+      const EdgeInsets.only(top: kToolbarHeight + 50, right: 8),
 }) async {
   final results = await Navigator.of(context).push(
     MaterialPageRoute<dynamic>(

--- a/lib/src/google_map_location_picker.dart
+++ b/lib/src/google_map_location_picker.dart
@@ -40,6 +40,7 @@ class LocationPicker extends StatefulWidget {
     this.countries,
     this.language,
     this.desiredAccuracy,
+    this.buttonMargin,
   });
 
   final String apiKey;
@@ -66,6 +67,8 @@ class LocationPicker extends StatefulWidget {
   final String language;
 
   final LocationAccuracy desiredAccuracy;
+  final EdgeInsets buttonMargin;
+
 
   @override
   LocationPickerState createState() => LocationPickerState();
@@ -425,6 +428,7 @@ class LocationPickerState extends State<LocationPicker> {
             key: mapKey,
             language: widget.language,
             desiredAccuracy: widget.desiredAccuracy,
+            buttonMargin: widget.buttonMargin,
           ),
         );
       }),
@@ -462,6 +466,7 @@ Future<LocationResult> showLocationPicker(
   Decoration resultCardDecoration,
   String language = 'en',
   LocationAccuracy desiredAccuracy = LocationAccuracy.best,
+  EdgeInsets buttonMargin = EdgeInsets.only(top: kToolbarHeight + 50, right: 8),
 }) async {
   final results = await Navigator.of(context).push(
     MaterialPageRoute<dynamic>(
@@ -487,6 +492,7 @@ Future<LocationResult> showLocationPicker(
           countries: countries,
           language: language,
           desiredAccuracy: desiredAccuracy,
+          buttonMargin: buttonMargin,
         );
       },
     ),

--- a/lib/src/map.dart
+++ b/lib/src/map.dart
@@ -38,6 +38,7 @@ class MapPicker extends StatefulWidget {
     this.resultCardPadding,
     this.language,
     this.desiredAccuracy,
+    this.buttonMargin,
   }) : super(key: key);
 
   final String apiKey;
@@ -63,6 +64,8 @@ class MapPicker extends StatefulWidget {
   final String language;
 
   final LocationAccuracy desiredAccuracy;
+
+  final EdgeInsets buttonMargin;
 
   @override
   MapPickerState createState() => MapPickerState();
@@ -202,6 +205,7 @@ class MapPickerState extends State<MapPicker> {
             layersButtonEnabled: widget.layersButtonEnabled,
             onToggleMapTypePressed: _onToggleMapTypePressed,
             onMyLocationPressed: _initCurrentLocation,
+            buttonMargin: widget.buttonMargin,
           ),
           pin(),
           locationCard(),
@@ -452,6 +456,7 @@ class _MapFabs extends StatelessWidget {
     @required this.layersButtonEnabled,
     @required this.onToggleMapTypePressed,
     @required this.onMyLocationPressed,
+    @required this.buttonMargin,
   })  : assert(onToggleMapTypePressed != null),
         super(key: key);
 
@@ -460,12 +465,12 @@ class _MapFabs extends StatelessWidget {
 
   final VoidCallback onToggleMapTypePressed;
   final VoidCallback onMyLocationPressed;
-
+  final EdgeInsets buttonMargin;
   @override
   Widget build(BuildContext context) {
     return Container(
       alignment: Alignment.topRight,
-      margin: const EdgeInsets.only(top: kToolbarHeight + 24, right: 8),
+      margin: buttonMargin,
       child: Column(
         children: <Widget>[
           if (layersButtonEnabled)


### PR DESCRIPTION
Add custom margin because some time overlap in the search textbox  in the issue https://github.com/humazed/google_map_location_picker/issues/88

```
LocationResult result = await showLocationPicker(
      context,
      "AIzaSyAfss1BCW8g4DtoLZF7vh_Xzz7AJJ5qzuc",
      initialCenter: LatLng(0, 0),
      automaticallyAnimateToCurrentLocation: true,
      myLocationButtonEnabled: true,
      requiredGPS: true,
      layersButtonEnabled: true,
      resultCardAlignment: Alignment.bottomCenter,
      desiredAccuracy: LocationAccuracy.best,
// custom buttonMargin
      buttonMargin: EdgeInsets.only(top: 150, right: 8),
    );
```